### PR TITLE
Fix blocked idler on calling the `stop` method

### DIFF
--- a/ayatanawebmail/idler.py
+++ b/ayatanawebmail/idler.py
@@ -22,6 +22,9 @@ class Idler(object):
 
     def stop(self):
 
+        if self.oConnection.oImap is not None:
+            # Send a NOOP command to interrupt the IDLE mode and free the blocked thread
+            self.oConnection.oImap.noop()
         self.oEvent.set()
 
     def join(self):


### PR DESCRIPTION
Calling the idler `stop` method sends a signal to the internally used
thread to finish its work. However, this thread is already blocked by
the IMAP IDLE mode and only released after reaching the IDLE timeout.
Thus, this commit sends another IMAP command (a simple NOOP) to abort
the IDLE mode so the thread can be released without any delay.

This commit fixes GitHub issue #26.