### PR TITLE
Do not fail in the idler stop method on connection drops

### DIFF
--- a/ayatanawebmail/idler.py
+++ b/ayatanawebmail/idler.py
@@ -23,8 +23,11 @@ class Idler(object):
     def stop(self):
 
         if self.oConnection.oImap is not None:
-            # Send a NOOP command to interrupt the IDLE mode and free the blocked thread
-            self.oConnection.oImap.noop()
+            try:
+                # Send a NOOP command to interrupt the IDLE mode and free the blocked thread
+                self.oConnection.oImap.noop()
+            except:
+                pass
         self.oEvent.set()
 
     def join(self):


### PR DESCRIPTION
On connection drops or standby events, sending a `noop` command is not
possible, and leads to a failing `stop` method in the `Idler` class.
This commit adds a try/except block to ignore that error case, since it
is not relevant for the `stop` method.

This fixes an error that was introduced by my PR #27. :disappointed: 