### PR TITLE
Pass host information when calling exec-on-receive

### DIFF
--- a/ayatanawebmail/application.py
+++ b/ayatanawebmail/application.py
@@ -983,7 +983,7 @@ class AyatanaWebmail(object):
 
                     try:
 
-                        subprocess.call((self.strCommand, sender, ilabel))
+                        subprocess.call((self.strCommand, sender, ilabel, oConnection.strHost))
 
                     except OSError as e:
 


### PR DESCRIPTION
Useful when you want to know which `mbsync` command to run when new mail arrives - to act upon which account.